### PR TITLE
Changed the order of newly added content

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -2,13 +2,6 @@
 sidebar_position: 1
 ---
 
-# Other languages
-
-Here is a list of community maintained translations. These are not guaranteed to always be up to date
-
-- Chinese: https://snowcutieowo.github.io/CommandTimer/#/
-
-
 # Getting Started
 
 Follow this tutorial to create your first scheduled command.
@@ -45,3 +38,10 @@ The global configuration file allows you to change the global behaviour of Comma
 - `timezoneOverwriteValue`: The timezone to overwrite the server timezone with (**This feature does not work right now**)
 - `language`: The language to use for the plugin. You can add more languages under the `languages` folder
 - `disablePapiPlaceholderWarnings`: Disable the warning message that appears when a PAPI placeholder is not used correctly
+
+
+# Other languages
+
+Here is a list of community maintained translations. These are not guaranteed to always be up to date
+
+- Chinese: https://snowcutieowo.github.io/CommandTimer/#/


### PR DESCRIPTION
Put the `Other Language` to the end of page and changed its title level, so the left sidebar could show the original title `Getting Started` correctly.