### PR TITLE
Fix INTERVAL type

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ java {
 }
 
 group = 'me.playbosswar.com'
-version = '8.11.2'
+version = '8.11.3'
 description = 'CommandTimer'
 
 repositories {
@@ -70,7 +70,7 @@ publishing {
         maven(MavenPublication) {
             groupId = 'me.playbosswar.com'
             artifactId = 'commandtimer'
-            version = '8.11.2'
+            version = '8.11.3'
 
             from components.java
         }

--- a/java17-build.gradle
+++ b/java17-build.gradle
@@ -10,7 +10,7 @@ java {
 
 
 group = 'me.playbosswar.com'
-version = '8.11.2'
+version = '8.11.3'
 description = 'CommandTimer'
 
 repositories {
@@ -63,7 +63,7 @@ publishing {
         maven(MavenPublication) {
             groupId = 'me.playbosswar.com'
             artifactId = 'commandtimer-java17'
-            version = '8.11.2'
+            version = '8.11.3'
 
             from components.java
         }

--- a/java21-build.gradle
+++ b/java21-build.gradle
@@ -10,7 +10,7 @@ java {
 
 
 group = 'me.playbosswar.com'
-version = '8.11.2'
+version = '8.11.3'
 description = 'CommandTimer'
 
 repositories {
@@ -68,7 +68,7 @@ publishing {
         maven(MavenPublication) {
             groupId = 'me.playbosswar.com'
             artifactId = 'commandtimer-java21'
-            version = '8.11.2'
+            version = '8.11.3'
             from components.java
         }
     }

--- a/src/main/java/me/playbosswar/com/tasks/CommandIntervalExecutorRunnable.java
+++ b/src/main/java/me/playbosswar/com/tasks/CommandIntervalExecutorRunnable.java
@@ -1,7 +1,6 @@
 package me.playbosswar.com.tasks;
 
 import me.playbosswar.com.CommandTimerPlugin;
-import org.bukkit.Bukkit;
 
 public class CommandIntervalExecutorRunnable implements Runnable {
     private final Task task;

--- a/src/main/java/me/playbosswar/com/tasks/CommandIntervalExecutorRunnable.java
+++ b/src/main/java/me/playbosswar/com/tasks/CommandIntervalExecutorRunnable.java
@@ -19,11 +19,10 @@ public class CommandIntervalExecutorRunnable implements Runnable {
             return;
         }
 
-        Bukkit.getScheduler().runTask(CommandTimerPlugin.getInstance(),
-                () -> tasksManager.processCommandExecution(task, task.getCommands().get(commandIndex)));
-        commandIndex++;
+        tasksManager.processCommandExecution(task, task.getCommands().get(commandIndex)); // no need to run in scheduler, we are already on the main thread
+        commandIndex++; // fix commandIndex incrementation
 
-        if(commandIndex == task.getCommands().size()) {
+        if(commandIndex >= task.getCommands().size()) {
             cancelled = true;
         }
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 main: me.playbosswar.com.CommandTimerPlugin
 name: "CommandTimer"
-version: "8.11.2"
+version: "8.11.3"
 description: "Schedule commands like you want"
 author: PlayBossWar
 api-version: 1.13


### PR DESCRIPTION
Interval execution type was broken due to incrementing the variable **after** the command was executed.

This tiny error lead to 2 main problems:
- First command newer executes.
- After executing the last commands, throws an exception (out of bounds). 